### PR TITLE
Simpler arithmetic and corrected regularization

### DIFF
--- a/api/src/main/java/com/yahoo/labs/yamall/ml/MiniBatchSGD.java
+++ b/api/src/main/java/com/yahoo/labs/yamall/ml/MiniBatchSGD.java
@@ -71,29 +71,12 @@ public class MiniBatchSGD implements Learner {
     private double accumulateGradient( Instance sample ) {
         gatherGradIter++;
 
-        double pred = 0;
-        for (Int2DoubleMap.Entry entry : sample.getVector().int2DoubleEntrySet()) {
-            double x_i;
-            if ((x_i = entry.getDoubleValue()) != 0.0) {
-                int key = entry.getIntKey();
-                double w_i = w[key];
-                pred += w_i * x_i;
-            }
-        }
+        double pred = predict(sample);
 
         final double grad = -lossFnc.negativeGradient(pred, sample.getLabel(), sample.getWeight());
 
         if (Math.abs(grad) > 1e-8) {
-
-            for (Int2DoubleMap.Entry entry : sample.getVector().int2DoubleEntrySet()) {
-                double x_i;
-                if ((x_i = entry.getDoubleValue()) != 0.0) {
-                    int key = entry.getIntKey();
-                    double G_i = Gbatch[key];
-                    G_i += (grad * x_i);
-                    Gbatch[key] = G_i;
-                }
-            }
+            sample.getVector().addScaledSparseVectorToDenseVector(Gbatch, grad);
         }
         return pred;
     }

--- a/api/src/main/java/com/yahoo/labs/yamall/ml/SGD.java
+++ b/api/src/main/java/com/yahoo/labs/yamall/ml/SGD.java
@@ -35,28 +35,13 @@ public class SGD implements Learner {
     public double update(Instance sample) {
         iter++;
 
-        double pred = 0;
-        for (Int2DoubleMap.Entry entry : sample.getVector().int2DoubleEntrySet()) {
-            double x_i;
-            if ((x_i = entry.getDoubleValue()) != 0.0) {
-                int key = entry.getIntKey();
-                double w_i = w[key];
-                pred += w_i * x_i;
-            }
-        }
+        double pred = predict(sample);
 
         final double negativeGrad = lossFnc.negativeGradient(pred, sample.getLabel(), sample.getWeight());
 
         if (Math.abs(negativeGrad) > 1e-8) {
-            final double a = eta * Math.sqrt(1 / (double)iter) ;
-
-            for (Int2DoubleMap.Entry entry : sample.getVector().int2DoubleEntrySet()) {
-                double x_i;
-                if ((x_i = entry.getDoubleValue()) != 0.0) {
-                    int key = entry.getIntKey();
-                    w[key] += a * negativeGrad * x_i;
-                }
-            }
+            final double a = eta * Math.sqrt(1 / (double)iter);
+            sample.getVector().addScaledSparseVectorToDenseVector(theta, a * negativeGrad);
         }
         return pred;
     }


### PR DESCRIPTION
replaced for loops with sparsevector operations.

I also realized that that the regularization in SVRG wasn't actually doing the right thing - technically we should be updating ALL of the weight vector coordinates with each update, but we only update the coordinates in common with the sparse example vector. This isn't quite the same because it drops updates that should have happened when the example didn't include a particular coordinate.

So I worked out what I believe is a way to do the proper updates lazily and still only run in O(sparsity) time. Basically the idea is that T applications of constant-step size gradient descent on lambda /2|W|^2 is equivalent to multiplying by (1-eta * lambda)^T.
