### PR TITLE
Alwaysbatching

### DIFF
--- a/api/src/main/java/com/yahoo/labs/yamall/ml/PerCoordinateFreeRex.java
+++ b/api/src/main/java/com/yahoo/labs/yamall/ml/PerCoordinateFreeRex.java
@@ -24,6 +24,8 @@ public class PerCoordinateFreeRex implements SVRGLearner {
     private transient double[] center;
     private transient double[] w;
 
+    private transient double[] regularization;
+
     private boolean useScaling = false;
     private boolean useWeightScaling = true;
 
@@ -45,6 +47,8 @@ public class PerCoordinateFreeRex implements SVRGLearner {
         w = new double[size_hash];
         center = new double[size_hash]; //default 0, but allows for FTRL with arbitrary centering.
 
+        regularization = new double[size_hash];
+
     }
 
     public double[] getDenseWeights() {
@@ -53,6 +57,12 @@ public class PerCoordinateFreeRex implements SVRGLearner {
     public void setCenter(double center[]) {
         for (int i=0; i<size_hash; i++) {
             this.center[i] = center[i];
+        }
+    }
+
+    public void setRegularization(double [] regularization, double scale) {
+        for (int i=0; i<size_hash; i++) {
+            this.regularization[i] = regularization[i] * scale;
         }
     }
 
@@ -68,7 +78,7 @@ public class PerCoordinateFreeRex implements SVRGLearner {
         iter++;
 
         if (this.useWeightScaling)
-            updateScalingVector(sample);
+            updateScalingVector(sample.getVector());
 
         double pred = predict(sample);
 
@@ -85,8 +95,8 @@ public class PerCoordinateFreeRex implements SVRGLearner {
     /*
     This scaling is similar to the one applied in normalized gradient descent, see SGD_VW
      */
-    public void updateScalingVector(Instance sample ) {
-        for (Int2DoubleMap.Entry entry : sample.getVector().int2DoubleEntrySet()) {
+    public void updateScalingVector(SparseVector featureVector) {
+        for (Int2DoubleMap.Entry entry : featureVector.int2DoubleEntrySet()) {
             int key = entry.getIntKey();
             double value = Math.abs(entry.getDoubleValue());
             if (value > scaling[key] )
@@ -131,8 +141,8 @@ public class PerCoordinateFreeRex implements SVRGLearner {
         this.useWeightScaling = flag;
     }
 
-    public void updateFromNegativeGrad(Instance sample, SparseVector negativeGrad) {
-        updateScalingVector(sample);
+    public void updateFromNegativeGrad(SparseVector featureVector, SparseVector negativeGrad) {
+        updateScalingVector(featureVector);
         for (Int2DoubleMap.Entry entry : negativeGrad.int2DoubleEntrySet()) {
             int key = entry.getIntKey();
             double negativeGrad_i = entry.getDoubleValue();
@@ -147,6 +157,7 @@ public class PerCoordinateFreeRex implements SVRGLearner {
             double sumGrads_i = sumGrads[key];
             double maxGrads_i = maxGrads[key];
             double inverseEtaSq_i = inverseEtaSq[key];
+            double regularization_i = regularization[key];
 
             sumGrads_i += missed_steps * negativeGrad;
             maxGrads_i = Math.max(maxGrads_i, Math.abs(negativeGrad));
@@ -158,7 +169,7 @@ public class PerCoordinateFreeRex implements SVRGLearner {
             inverseEtaSq[key] = inverseEtaSq_i;
 
             if (inverseEtaSq_i>1e-7) {
-                double offset = (Math.signum(sumGrads_i)) * (Math.exp(k_inv * Math.abs(sumGrads_i) / Math.sqrt(inverseEtaSq_i)) - 1.0);
+                double offset = (Math.signum(sumGrads_i)) * (Math.exp(k_inv * Math.abs(sumGrads_i) / (Math.sqrt(inverseEtaSq_i) + regularization_i)) - 1.0);
 
                 if (useScaling) {
                     double scaling_i = scaling[key];

--- a/api/src/main/java/com/yahoo/labs/yamall/ml/PerCoordinateFreeRex.java
+++ b/api/src/main/java/com/yahoo/labs/yamall/ml/PerCoordinateFreeRex.java
@@ -24,8 +24,6 @@ public class PerCoordinateFreeRex implements SVRGLearner {
     private transient double[] center;
     private transient double[] w;
 
-    private transient double[] regularization;
-
     private boolean useScaling = false;
     private boolean useWeightScaling = true;
 
@@ -47,7 +45,6 @@ public class PerCoordinateFreeRex implements SVRGLearner {
         w = new double[size_hash];
         center = new double[size_hash]; //default 0, but allows for FTRL with arbitrary centering.
 
-        regularization = new double[size_hash];
 
     }
 
@@ -57,12 +54,6 @@ public class PerCoordinateFreeRex implements SVRGLearner {
     public void setCenter(double center[]) {
         for (int i=0; i<size_hash; i++) {
             this.center[i] = center[i];
-        }
-    }
-
-    public void setRegularization(double [] regularization, double scale) {
-        for (int i=0; i<size_hash; i++) {
-            this.regularization[i] = regularization[i] * scale;
         }
     }
 
@@ -157,7 +148,6 @@ public class PerCoordinateFreeRex implements SVRGLearner {
             double sumGrads_i = sumGrads[key];
             double maxGrads_i = maxGrads[key];
             double inverseEtaSq_i = inverseEtaSq[key];
-            double regularization_i = regularization[key];
 
             sumGrads_i += missed_steps * negativeGrad;
             maxGrads_i = Math.max(maxGrads_i, Math.abs(negativeGrad));
@@ -169,7 +159,7 @@ public class PerCoordinateFreeRex implements SVRGLearner {
             inverseEtaSq[key] = inverseEtaSq_i;
 
             if (inverseEtaSq_i>1e-7) {
-                double offset = (Math.signum(sumGrads_i)) * (Math.exp(k_inv * Math.abs(sumGrads_i) / (Math.sqrt(inverseEtaSq_i) + regularization_i)) - 1.0);
+                double offset = (Math.signum(sumGrads_i)) * (Math.exp(k_inv * Math.abs(sumGrads_i) / (Math.sqrt(inverseEtaSq_i))) - 1.0);
 
                 if (useScaling) {
                     double scaling_i = scaling[key];

--- a/api/src/main/java/com/yahoo/labs/yamall/ml/SVRGLearner.java
+++ b/api/src/main/java/com/yahoo/labs/yamall/ml/SVRGLearner.java
@@ -47,5 +47,4 @@ public interface SVRGLearner extends Learner {
      */
     void batchUpdateCoordinate(int key, double negativeGrad, int missed_steps);
 
-    void setRegularization(double [] regularization, double scale);
 }

--- a/api/src/main/java/com/yahoo/labs/yamall/ml/SVRGLearner.java
+++ b/api/src/main/java/com/yahoo/labs/yamall/ml/SVRGLearner.java
@@ -20,7 +20,7 @@ public interface SVRGLearner extends Learner {
      * @param sample
      * @param negativeGrad
      */
-    void updateFromNegativeGrad(Instance sample, SparseVector negativeGrad);
+    void updateFromNegativeGrad(SparseVector featureVector, SparseVector negativeGrad);
 
 
     /**
@@ -46,4 +46,6 @@ public interface SVRGLearner extends Learner {
      * @param missed_steps
      */
     void batchUpdateCoordinate(int key, double negativeGrad, int missed_steps);
+
+    void setRegularization(double [] regularization, double scale);
 }


### PR DESCRIPTION
A number of changes in relatively few lines:

1. In SGD phase, continue to update the batch gradient with newly acquired data. This is facilitated by a somewhat different averaging procedure.
2. Add option to use |x| regularization scaled with batch standard deviation for theoretically good convergence.
3. Force batch phase to always be as large as the total number of SGD iterations. If used without resets, this results in the same convergence (up to logs) as normal SGD.
4. Do one "full" minibatch-sgd update after each batch phase using the full batch gradient.
5. Refactor updates of batch scalings so that SVRG keeps track of a scaling vector and updates the baseLearner's scalings after the end of the batch phase. This makes things a little less hack and should make it easier to migrate to spark.